### PR TITLE
Parallelized clone

### DIFF
--- a/git-p4.py
+++ b/git-p4.py
@@ -2808,7 +2808,9 @@ class P4Sync(Command, P4UserMap):
                 optparse.make_option("--print-batch-size", dest="printBatchSize", type="int"),
                 optparse.make_option("--describe-batch-size", dest="describeBatchSize", type="int"),
                 optparse.make_option("--tmp-dir", dest="tempDir", help="Directory to store temporary files"),
-                optparse.make_option("--keep-tmp-files", dest="keepTempFiles", help="Do not remove temporary files after commit", action="store_true")
+                optparse.make_option("--keep-tmp-files", dest="keepTempFiles", help="Do not remove temporary files after commit", action="store_true"),
+                optparse.make_option("--no-disk-free-check", dest="noDiskFreeCheck", action='store_true',
+                            help="Skip checking if enough free disk space is availaible")
         ]
         self.description = """Imports from Perforce into a git repository.\n
     example:
@@ -2843,6 +2845,7 @@ class P4Sync(Command, P4UserMap):
         self.largeFileSystem = None
         self.suppress_meta_comment = False
         self.threads = 10
+        self.noDiskFreeCheck = False
         self.printBatchSize = 1000
         self.describeBatchSize = 100
         self.tempDir = ""
@@ -3122,7 +3125,7 @@ class P4Sync(Command, P4UserMap):
                 if "data" in marshalled:
                     err = marshalled["data"].rstrip()
 
-        if not err and 'fileSize' in self.stream_file:
+        if not err and 'fileSize' in self.stream_file and not self.noDiskFreeCheck:
             required_bytes = int((4 * int(self.stream_file["fileSize"])) - calcDiskFree())
             if required_bytes > 0:
                 err = 'Not enough space left on %s! Free at least %i MB.' % (
@@ -3770,7 +3773,7 @@ class P4Sync(Command, P4UserMap):
                 self.updateOptionDict(d)
                 files = self.extractFilesFromCommit(d)
                 fileArgs = self.prepFileArgs(files)
-                
+
                 cl = {"files": files, "fileArgs": fileArgs, "change": change, "description": d}
 
                 fileArgs = cl["fileArgs"]
@@ -4450,6 +4453,7 @@ class P4Sync(Command, P4UserMap):
                 system(["git", "symbolic-ref", head_ref, self.branch])
 
         return True
+
 
 class P4Rebase(Command):
     def __init__(self):

--- a/git-p4.py
+++ b/git-p4.py
@@ -41,6 +41,7 @@ import logging
 import pprint
 import traceback
 import signal
+import pprint
 
 # On python2.7 where raw_input() and input() are both availble,
 # we want raw_input's semantics, but aliased to input for python3
@@ -3958,6 +3959,7 @@ class P4Sync(Command, P4UserMap):
                     print("IO error with git fast-import. Is your git version recent enough?")
                     print("IO error details: {}".format(err))
                     print("gitError output:", self.gitError.read())
+                    pprint.pprint(toCommit)
                     cancelEvent.set()
                     break
                 except ValueError as err:
@@ -3965,6 +3967,7 @@ class P4Sync(Command, P4UserMap):
                     print("Value error with git fast-import")
                     print("Value error details: {}".format(err))
                     print("gitError output:", self.gitError.read())
+                    pprint.pprint(toCommit)
                     cancelEvent.set()
                     break
                 except Exception as err:

--- a/git-p4.py
+++ b/git-p4.py
@@ -3946,6 +3946,10 @@ class P4Sync(Command, P4UserMap):
                     print("gitError output:", self.gitError.read())
                     cancelEvent.set()
                     break
+                except Exception as err:
+                    cancelEvent.set()
+                    logit("Exception: {}".format(err))
+                    traceback.print_exc()
 
                 cl = done.pop(changes[commited])
 

--- a/git-p4.py
+++ b/git-p4.py
@@ -2729,6 +2729,10 @@ class View(object):
             if "code" in res and res["code"] == "error":
                 # assume error is "... file(s) not in client view"
                 continue
+            if "p4ExitCode" in res:
+                # assume error is "... file(s) not in client view"
+                logit("Cannot get clientFile from 'p4 where' result. Ignoring... Files: {}".format(fileArgs))
+                continue
             if "clientFile" not in res:
                 logit("Cannot get clientFile from 'p4 where' result")
                 logit(pprint.pformat(res))

--- a/git-p4.py
+++ b/git-p4.py
@@ -2729,9 +2729,9 @@ class View(object):
             if "code" in res and res["code"] == "error":
                 # assume error is "... file(s) not in client view"
                 continue
-            if "p4ExitCode" in res:
+            if "p4ExitCode" in res and res["p4ExitCode"] != 0:
                 # assume error is "... file(s) not in client view"
-                logit("Cannot get clientFile from 'p4 where' result. Ignoring... Files: {}".format(fileArgs))
+                logit("Cannot get clientFile from 'p4 where' result. Ignoring... Files: {}. Result: {}".format(fileArgs, res))
                 continue
             if "clientFile" not in res:
                 logit("Cannot get clientFile from 'p4 where' result")

--- a/git-p4.py
+++ b/git-p4.py
@@ -3716,7 +3716,7 @@ class P4Sync(Command, P4UserMap):
 
                 lock.acquire()
                 downloaded += 1
-                printProgress()
+                # printProgress()
                 lock.release()
     
                 out.put_nowait({
@@ -3739,6 +3739,7 @@ class P4Sync(Command, P4UserMap):
                 if commited < len(changes):
                     try:
                         task = out.get(timeout=0.5)
+                        print("downloaded: change {} downloaded".format(task["change"]))
                     except queue.Empty:
                         continue
 
@@ -3748,14 +3749,17 @@ class P4Sync(Command, P4UserMap):
                     try:
                         toCommit = done.pop(changes[commited])
                     except KeyError:
+                        print("committer: waiting for {}".format(changes[commited]))
                         break
-                    
+
                     self.commit(toCommit["description"], toCommit["files"], self.branch,
                                 self.initialParent, localPath=toCommit["filePath"])
                     
+                    print("committer: {} committed, ".format(changes[commited]))
                     lock.acquire()
                     commited += 1
-                    printProgress()
+                    print("committer: Downloaded: %s / %s, Committed: %s / %s" % (downloaded, len(changes), commited, len(changes)))
+                    # printProgress()
                     lock.release()
 
         # start the commit downloader threads


### PR DESCRIPTION
Important changes:
- The script now runs `p4 describe` on a list of CLs instead of running the command for each one of them. This should improve the overall speed of the clone. ⚠️ The server may return a `Request too large` error or equivalent if the CLs contain too many changes. If that's the case, the number of CLs per call can be controlled with `--describe-batch-size` (default 1000).
- CL files are now processed in batches and distributed across a worker pool. Batch size can be controlled with `--print-batch-size` (default 1000 files max per `p4 print`). If a CL is bigger than that number, all the chunks will be distributed across the available threads and processed in parallel.
- Ram consumption **should** in theory be kept to a minimum and be a produce of the number of threads * the number of files being processed. `p4 print` batches are streaming to a file on disk, and once it has been processed, the file is closed and the memory should be GC'ed. Python is notoriously bad at giving back memory though, so memory usage should be monitored.